### PR TITLE
Fix fetch depth for master branch

### DIFF
--- a/.github/workflows/build-image-manager.yaml
+++ b/.github/workflows/build-image-manager.yaml
@@ -30,6 +30,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 0
+
+      - name: Fetch master branch
+        run: git fetch origin master:refs/remotes/origin/master --depth=1
 
       - id: filter
         uses: dorny/paths-filter@v3


### PR DESCRIPTION
Fixing fetch depth for master branch.

The action tried to compare changes against the master branch, but this branch was not fetched with the correct depth.

```
Run dorny/paths-filter@v3
Get current git ref
Changes will be detected between origin/master and master
Searching for merge-base origin/master...master
  /usr/bin/git show-ref origin/master
  /usr/bin/git show-ref master
  /usr/bin/git fetch --no-tags --depth=100 origin origin/master master
  fatal: couldn't find remote ref origin/master
Error: The process '/usr/bin/git' failed with exit code 128
```