### PR TITLE
Fix pushing Docker images

### DIFF
--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -3,10 +3,13 @@ name: Build API Image
 on:
   workflow_call:
     inputs:
-      sha:
+      version:
         required: true
         type: string
       dockerfile:
+        required: true
+        type: string
+      repo_name:
         required: true
         type: string
     secrets:
@@ -18,8 +21,6 @@ on:
 jobs:
   build-api:
     runs-on: ubuntu-latest
-    env:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
     steps:
       - uses: actions/checkout@v4
 
@@ -36,4 +37,4 @@ jobs:
           file: ${{ inputs.dockerfile }}
           push: true
           tags: |
-            ${{ env.DOCKERHUB_USERNAME }}/weather_api:dev-${{ inputs.sha }}
+            ${{ inputs.repo_name }}:api_dev-${{ inputs.version }}

--- a/.github/workflows/build-image-manager.yaml
+++ b/.github/workflows/build-image-manager.yaml
@@ -66,8 +66,9 @@ jobs:
     if: needs.detect-changes.outputs.api == 'true'
     uses: ./.github/workflows/build-api.yaml
     with:
-      sha: alpha-${{ github.event.issue.number }}
+      version: alpha-${{ github.event.issue.number }}
       dockerfile: docker/Dockerfile
+      repo_name: ramossrenato/weather_api
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -77,8 +78,9 @@ jobs:
     if: needs.detect-changes.outputs.metrics_exporter == 'true'
     uses: ./.github/workflows/build-metrics-export.yaml
     with:
-      sha: alpha-${{ github.event.issue.number }}
+      version: alpha-${{ github.event.issue.number }}
       dockerfile: exporter/Dockerfile
+      repo_name: ramossrenato/weather_api
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-metrics-export.yaml
+++ b/.github/workflows/build-metrics-export.yaml
@@ -3,10 +3,13 @@ name: Build Metrics Export Image
 on:
   workflow_call:
     inputs:
-      sha:
+      version:
         required: true
         type: string
       dockerfile:
+        required: true
+        type: string
+      repo_name:
         required: true
         type: string
     secrets:
@@ -33,4 +36,4 @@ jobs:
           file: ${{ inputs.dockerfile }}
           push: true
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/metrics-exporter:dev-${{ inputs.sha }}
+            ${{ inputs.repo_name }}:metrics_dev-${{ inputs.version }}


### PR DESCRIPTION
We can not use the username (as secret) as repo name to set the tag.

Action uses secrets as `***` and this value is empty when used as string (e.g tag name)

<img width="1070" height="397" alt="Screenshot 2025-08-23 at 19 42 19" src="https://github.com/user-attachments/assets/bfdab11a-8158-40f6-89b0-1609e354a5ee" />
