### PR TITLE
Create dedicated repositories for each service

### DIFF
--- a/.github/workflows/build-image-manager.yaml
+++ b/.github/workflows/build-image-manager.yaml
@@ -80,7 +80,7 @@ jobs:
     with:
       version: alpha-${{ github.event.issue.number }}
       dockerfile: exporter/Dockerfile
-      repo_name: ramossrenato/weather_api
+      repo_name: ramossrenato/metrics_exporter
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-metrics-export.yaml
+++ b/.github/workflows/build-metrics-export.yaml
@@ -19,7 +19,7 @@ on:
         required: true
 
 jobs:
-  build-consumer:
+  build-metrics-exporter:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We want to upload the docker images to their respective repositories

So, I created a repo to api and another one to metrics exporter

<img width="524" height="321" alt="Screenshot 2025-08-23 at 20 23 26" src="https://github.com/user-attachments/assets/1f0700f3-d5b0-4ef1-87a9-503813a4ae92" />
