### PR TITLE
Fix action token usage

### DIFF
--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -20,8 +20,6 @@ on:
         required: true
       DOCKERHUB_TOKEN:
         required: true
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   build-api:
@@ -58,6 +56,3 @@ jobs:
       result: ${{ needs.build-api.result }}
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: read
-      pull-requests: write

--- a/.github/workflows/build-metrics-export.yaml
+++ b/.github/workflows/build-metrics-export.yaml
@@ -20,8 +20,6 @@ on:
         required: true
       DOCKERHUB_TOKEN:
         required: true
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   build-metrics-exporter:
@@ -58,6 +56,3 @@ jobs:
       result: ${{ needs.build-metrics-exporter.result }}
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: read
-      pull-requests: write

--- a/.github/workflows/post-run.yaml
+++ b/.github/workflows/post-run.yaml
@@ -1,3 +1,7 @@
+permissions:
+  contents: read
+  pull-requests: write
+
 name: Docker Build Post Run
 
 on:


### PR DESCRIPTION
We can not pass `GITHUB_TOKEN` directly to the workflow calls.

error:

```
Invalid workflow file: .github/workflows/build-image-manager.yaml#L67
error parsing called workflow
".github/workflows/build-image-manager.yaml"
-> "./.github/workflows/build-api.yaml" (source branch with sha:7ee774df0d4e9ad8157a238f19ed00072d46029c)
: secret name `GITHUB_TOKEN` within `workflow_call` can not be used since it would collide with system reserved name
```