### PR TITLE
Remove unnecessary secrets

### DIFF
--- a/.github/workflows/post-run.yaml
+++ b/.github/workflows/post-run.yaml
@@ -22,9 +22,6 @@ on:
       hub_url:
         required: true
         type: string
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 jobs:
   post-comment:


### PR DESCRIPTION
We have removed the GITHUB_TOKEN secret from the post-run workflow as it is not needed.

error:

````
Invalid workflow file: .github/workflows/build-image-manager.yaml#L81
error parsing called workflow
".github/workflows/build-image-manager.yaml"
-> "./.github/workflows/build-metrics-export.yaml" (source branch with sha:7b7d23b8f3fff7daef0a44d7a0feaa53bfafb5cc)
--> "./.github/workflows/post-run.yaml" (source branch with sha:7b7d23b8f3fff7daef0a44d7a0feaa53bfafb5cc)
: secret name `GITHUB_TOKEN` within `workflow_call` can not be used since it would collide with system reserved name
````