### PR TITLE
Fix ci workflow

### DIFF
--- a/.github/workflows/build-image-manager.yaml
+++ b/.github/workflows/build-image-manager.yaml
@@ -88,7 +88,7 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   post-manager:
-    needs: [build-api, build-metrics-exporter]
+    needs: [detect-changes, build-api, build-metrics-exporter]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We want to run post-manager even if no changes are detected.